### PR TITLE
A fix to have hound use the babel-eslint for parsing es6

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,5 +20,6 @@
     ],
     "rules": {
          "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }]
-    }
+    },
+    "parser": "babel-eslint"
 }


### PR DESCRIPTION
Update the hound setting to babel-eslint