### PR TITLE
#166079763 Fix signout rendering twice on clicking logout

### DIFF
--- a/src/components/SignedInLinks.js
+++ b/src/components/SignedInLinks.js
@@ -4,7 +4,6 @@ import { NavLink } from 'react-router-dom';
 class SignedInLinks extends Component {
   handleLogout = () => {
     localStorage.clear();
-    window.location.replace('/');
   };
 
   render() {


### PR DESCRIPTION
#### What does this PR do?
Implements a fix that removes the double rendering of the navbar when the signout button is clicked.

#### Relevant PT story
https://www.pivotaltracker.com/story/show/166079763